### PR TITLE
use generic modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.4.0] - 2022-06-03
+
+### Changed
+
+- Use generic modules instead of classroom specific modules in [19](https://github.com/OSC/bc_classroom_jupyter/pull/19).
+
+## [0.3.1] - 2022-02-09
+
+### Added
+
+- PIs can create a submission directory if the shell script to do it exists
+  in [18](https://github.com/OSC/bc_classroom_jupyter/pull/18).
+
+
 ## [0.3.0] - 2022-01-12
 
 ### Changed
@@ -36,7 +50,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/OSC/bc_classroom_jupyter/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/OSC/bc_classroom_jupyter/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/OSC/bc_classroom_jupyter/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/OSC/bc_classroom_jupyter/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/OSC/bc_classroom_jupyter/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/OSC/bc_classroom_jupyter/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/OSC/bc_classroom_jupyter/compare/v0.2.0...v0.2.1

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -17,6 +17,7 @@
       size: tokens[1].nil? ? 1 : tokens[1].to_i,
       time: tokens[2].nil? ? 1 : tokens[2].to_i,
       compute_cluster: tokens[3].nil? ? 'pitzer' : tokens[3].to_s,
+      module_type: tokens[4].nil? ? 'default' : tokens[4].to_s,
       account: v,
     }
   end
@@ -33,10 +34,13 @@ form:
   - size
   - time
   - compute_cluster
+  - module_type
 attributes:
   account:
     widget: "hidden_field"
   compute_cluster:
+    widget: "hidden_field"
+  module_type:
     widget: "hidden_field"
   jupyterlab_switch:
     widget: "check_box"
@@ -113,7 +117,8 @@ attributes:
       - [
         "<%= cr[:name].gsub('_', ' ') %>", "<%= cr[:name] %>",
         data-set-account: "<%= cr[:account] %>",
-        data-set-compute-cluster: "<%= cr[:compute_cluster] %>"
+        data-set-compute-cluster: "<%= cr[:compute_cluster] %>",
+        data-set-module-type: "<%= cr[:module_type] %>"
         ]
       <%- end %>
   <%- else -%>

--- a/template/before.sh.erb
+++ b/template/before.sh.erb
@@ -8,8 +8,11 @@ source /bin/save_passwd_as_secret
 source /bin/create_salt_and_sha1
 
 
+export OSC_CLASS_ID="<%= context.classroom %>"
+export OSC_PROJECT_ID="<%= context.account %>"
+
 module purge
-module load project/classroom xalt/latest jupyter/<%= context.classroom %>
+module load project/classroom xalt/latest classroom_jupyter/<%= context.module_type %>
 
 # Safari users hit this error https://github.com/jupyterlab/jupyterlab/issues/5486
 # so let's make a new workspace dir that's this job's PWD and copy the defult /lab


### PR DESCRIPTION
use generic modules that rely on `OSC_CLASS_ID` and `OSC_PROJECT_ID` environment variables to load the classroom instead of using specific modules for each and every classroom.