### PR TITLE
relax startup probe for apps that need to copy lots of data

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -52,6 +52,10 @@ script:
       port: "8080"
       cpu: "<%= container_sizes[size.to_sym][:cpu] %>m"
       memory: "<%= container_sizes[size.to_sym][:memory] %>Gi"
+      startup_probe:
+        initial_delay_seconds: 60
+        period_seconds: 60
+        failure_threshold: 10
     node_selector:
       node-role.kubernetes.io/ondemand: ''
     mounts:

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -53,7 +53,7 @@ script:
       cpu: "<%= container_sizes[size.to_sym][:cpu] %>m"
       memory: "<%= container_sizes[size.to_sym][:memory] %>Gi"
       startup_probe:
-        initial_delay_seconds: 60
+        initial_delay_seconds: 30
         period_seconds: 60
         failure_threshold: 10
     node_selector:


### PR DESCRIPTION
relax startup probe for apps that need to copy lots of data.  This gives those classes some extra time to do that before they go into crashloop backoff.