### PR TITLE
Revert "relax startup probe for apps that need to copy lots of data"

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -52,10 +52,6 @@ script:
       port: "8080"
       cpu: "<%= container_sizes[size.to_sym][:cpu] %>m"
       memory: "<%= container_sizes[size.to_sym][:memory] %>Gi"
-      startup_probe:
-        initial_delay_seconds: 30
-        period_seconds: 60
-        failure_threshold: 10
     node_selector:
       node-role.kubernetes.io/ondemand: ''
     mounts:


### PR DESCRIPTION
Reverts OSC/bc_classroom_jupyter#23

Revert this as we're going to just tell folks the best practice is to hold data files in a different directory and reference them through their full path.