### PR TITLE
Support GPUs

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -131,18 +131,14 @@ attributes:
       * **extra-large** - 8 cores & 32 GB of memory.
 
   gpus:
-  <%- classrooms.map do |c| -%>
-    <%- if c[:gpus].to_i > 0 %>
     widget: number_field
     label: 'GPUs'
     value: 0
     help: |
       Select '0' for CPU only.
     min: 0
-    max: <%= c[:gpus].to_i %>
+    max: 1
     step: 1
-    <%- end %>
-  <%- end %>
 
   classroom:
   <%- if classrooms.size >= 1 -%>
@@ -154,7 +150,15 @@ attributes:
         data-set-account: "<%= cr[:account] %>",
         data-set-cluster-fs: "<%= cr[:cluster_fs] %>",
         data-set-module-type: "<%= cr[:module_type] %>",
-        data-set-cluster: "<%= cr[:cluster] %>"
+        data-set-cluster: "<%= cr[:cluster] %>",
+        <%- if cr[:gpus].to_i.positive? -%>
+        data-set-gpus: 0,
+        data-max-gpus: <%= cr[:gpus].to_i %>,
+        data-hide-gpus: false,
+        <%- else -%>
+        data-set-gpus: 0,
+        data-hide-gpus: true,
+        <%- end -%>
         ]
       <%- end %>
   <%- else -%>

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -29,8 +29,9 @@
           name: name,
           size: size_to_num(class_config.fetch('size', 'small')),
           hours: class_config.fetch('hours', 1).to_i,
-          cluster_fs: class_config.fetch('cluster_fs', 'cardinal'),
+          cluster_fs: class_config.fetch('cluster_fs', 'ascend'),
           module_type: class_config.fetch('module_type', 'default'),
+          gpus: class_config.fetch('gpus', 0).to_i,
           account: class_config.fetch('project', nil),
           cluster: cluster_id
         }
@@ -50,6 +51,7 @@ form:
   - jupyterlab_switch
   - size
   - hours
+  - gpus
   - cluster_fs
   - module_type
 attributes:
@@ -127,6 +129,20 @@ attributes:
       * **medium** - 2 cores & 8 GB of memory.
       * **large** - 4 cores & 16 GB of memory.
       * **extra-large** - 8 cores & 32 GB of memory.
+
+  gpus:
+  <%- classrooms.map do |c| -%>
+    <%- if c[:gpus].to_i > 0 %>
+    widget: number_field
+    label: 'GPUs'
+    value: 0
+    help: |
+      Select '0' for CPU only.
+    min: 0
+    max: <%= c[:gpus].to_i %>
+    step: 1
+    <%- end %>
+  <%- end %>
 
   classroom:
   <%- if classrooms.size >= 1 -%>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -39,6 +39,9 @@
 script:
   accounting_id: "<%= account %>"
   wall_time: "<%= hours.to_f * 3600 %>"
+  <%- if gpus.to_i > 0 -%>
+  gpus_per_node: <%= gpus.to_i %>
+  <%- end -%>
   native:
     container:
       name: "jupyter"


### PR DESCRIPTION
## What's Changed
* Set the default `cluster_fs` to `ascend`.
* Added GPU support. The `gpus` field is available when a classroom is configured with the `gpus` option set to a value greater than 0.
